### PR TITLE
Return #AABBCC representation when the color is opaque.

### DIFF
--- a/src/AngleSharp.Css/Values/Primitives/Color.cs
+++ b/src/AngleSharp.Css/Values/Primitives/Color.cs
@@ -337,7 +337,7 @@ namespace AngleSharp.Css.Values
             var green = 0.0;
             var blue = 0.0;
 
-            if (ratio < 1.0) 
+            if (ratio < 1.0)
             {
                 w *= ratio;
                 b *= ratio;
@@ -354,7 +354,7 @@ namespace AngleSharp.Css.Values
             var v = 1.0 - b;
             var n = w + f * (v - w);
 
-            switch (p) 
+            switch (p)
             {
                 default:
                 case 6:
@@ -390,6 +390,19 @@ namespace AngleSharp.Css.Values
                 }
                 else
                 {
+                    const double delta = 0.000_000_1d;
+                    if (Math.Abs(Alpha - 1d) <= delta) // opaque color
+                    {
+                        var hexRepresentation = String.Join(string.Empty,
+                            "#",
+                            R.ToString("X2", CultureInfo.InvariantCulture),
+                            G.ToString("X2", CultureInfo.InvariantCulture),
+                            B.ToString("X2", CultureInfo.InvariantCulture)
+                        );
+
+                        return hexRepresentation;
+                    }
+
                     var fn = FunctionNames.Rgba;
                     var args = String.Join(", ", new[]
                     {


### PR DESCRIPTION
# Change the logic of color value generation

## Description

### Old behaviour
The color representation was generated using `rgba` css function regardless of the inputted value.
Example: Any of `#AABBCC`, `rgb(x, y, z)`, `hsl(x, y, z)`, `rgba(x, y, z, a)`, `hsla(x, y, z, a)` are converted to `rgba(x1, y1, z1, a1)` representation.

### New behaviour and breaking changes
If inputted color is opaque, convert it to the simplest and widely supported `#AABBCC` form.
Tests are not adjusted to the new logic.
